### PR TITLE
Add footer, separate CSS and support tonal palette generation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,17 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  -webkit-box-shadow: none;
+  padding: var(--spacing-8) 0;
+}
+
+.content {
+  flex: 1;
+  overflow: auto;
+}
+
+.footer {
+  height: auto;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,13 @@ import ColorPicker, {
 } from "./components/color-picker/ColorPicker.tsx";
 import { useRef, useState } from "react";
 import { MessageMaterialThemeService } from "./services/MaterialThemeService.ts";
+import Footer from "./components/footer/Footer.tsx";
 
 function App() {
   const colorPickerRef = useRef<ColorPickerRef>(null);
   const [themeName, setThemeName] = useState<string>("");
+  const [generateTonalPalettes, setGenerateTonalPalettes] =
+    useState<boolean>(false);
 
   const materialService = new MessageMaterialThemeService();
 
@@ -16,7 +19,7 @@ function App() {
     console.log(`${progress.toString()}/${total.toString()}`);
   };
 
-  const onGenerate = () => {
+  const onGenerateClicked = () => {
     const theme = themeName != "" ? themeName : "material-theme";
     const color = colorPickerRef.current?.getColor();
     if (!color) {
@@ -24,18 +27,8 @@ function App() {
       return;
     }
 
-    // TODO Retrieve tonal palettes value from checkbox
-    const withTonalPalettes = false;
-    const withStateLayers = true;
-
     materialService
-      .generateTheme(
-        theme,
-        color,
-        withTonalPalettes,
-        withStateLayers,
-        onProgress,
-      )
+      .generateTheme(theme, color, generateTonalPalettes, true, onProgress)
       .then(() => {
         console.log("Theme generated");
       })
@@ -45,40 +38,60 @@ function App() {
   };
 
   return (
-    <>
-      <p className="body-m">
-        Material theme builder that allows you to generate assets based on
-        Material 3.
-      </p>
-      <div className="form-group">
-        <label className="input-label body-m" htmlFor="input-theme-name">
-          Theme Name
-        </label>
-        <input
-          className="input"
-          type="text"
-          placeholder="material-theme"
-          id="input-theme-name"
-          value={themeName}
-          onChange={(e) => {
-            setThemeName(e.target.value);
-          }}
-        />
-        <div style={{ height: "var(--spacing-16)" }}></div>
-        <ColorPicker ref={colorPickerRef} />
+    <div className="container">
+      <div className="content">
+        <p className="body-m">
+          Material theme builder that allows you to generate assets based on
+          Material 3.
+        </p>
+        <div className="form-group">
+          <label className="input-label body-m" htmlFor="input-theme-name">
+            Theme Name
+          </label>
+          <input
+            className="input"
+            type="text"
+            placeholder="material-theme"
+            id="input-theme-name"
+            value={themeName}
+            onChange={(e) => {
+              setThemeName(e.target.value);
+            }}
+          />
+          <div style={{ height: "var(--spacing-16)" }}></div>
+          <ColorPicker ref={colorPickerRef} />
+          <div style={{ height: "var(--spacing-16)" }}></div>
+
+          <span className="body-m">Additional Options</span>
+          <div className="checkbox-container">
+            <input
+              className="checkbox-input"
+              type="checkbox"
+              id="generate-color-palettes"
+              checked={generateTonalPalettes}
+              onChange={(e) => {
+                setGenerateTonalPalettes(e.target.checked);
+              }}
+            />
+            <label htmlFor="generate-color-palettes" className="checkbox">
+              Generate color palettes
+            </label>
+          </div>
+        </div>
+
+        <div style={{ height: "var(--spacing-24)" }}></div>
+
+        <button
+          type="button"
+          data-appearance="primary"
+          className="full-width-button"
+          onClick={onGenerateClicked}
+        >
+          Generate Theme
+        </button>
       </div>
-
-      <div style={{ height: "var(--spacing-24)" }}></div>
-
-      <button
-        type="button"
-        data-appearance="primary"
-        className="full-width-button"
-        onClick={onGenerate}
-      >
-        Generate Theme
-      </button>
-    </>
+      <Footer />
+    </div>
   );
 }
 

--- a/src/components/color-picker/ColorPicker.css
+++ b/src/components/color-picker/ColorPicker.css
@@ -1,0 +1,77 @@
+.color-input {
+  padding-block: 0;
+  padding-inline: var(--spacing-8) 0;
+  height: var(--spacing-32);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  border: 1px transparent solid;
+
+  &:focus-within {
+    background: var(--background-primary);
+    border: 1px var(--accent-primary) solid;
+  }
+
+  &:hover:focus-within {
+    background: var(--background-primary);
+    border: 1px var(--accent-primary) solid;
+  }
+}
+
+.color-input-color {
+  border-radius: var(--spacing-4);
+  width: 14px;
+  height: 14px;
+  background: white;
+  outline: 2px transparent solid;
+}
+
+.color-input-color:hover {
+  outline: 2px var(--accent-primary) solid;
+}
+
+.color-input-text {
+  background-color: transparent !important;
+  border: none;
+  flex: 1;
+  font-family: "worksans", "vazirmatn", sans-serif;
+  font-weight: var(--font-weight-regular);
+  font-size: var(--font-size-m);
+  line-height: var(--font-line-height-l);
+  padding-block: var(--spacing-4);
+
+  :focus {
+    border: 0 transparent solid;
+    outline: 0 transparent solid;
+  }
+}
+
+.color-picker {
+  border: none;
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  background: none;
+  padding: 0;
+  padding-block: 0;
+  padding-inline: 0;
+  border-radius: var(--spacing-4);
+}
+
+.color-picker::-webkit-color-swatch-wrapper {
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  padding-block: 0;
+  padding-inline: 0;
+}
+
+.color-picker::-webkit-color-swatch {
+  width: 14px;
+  height: 14px;
+  border: none;
+}
+
+.color-picker:hover {
+  outline: 2px var(--accent-primary) solid;
+}

--- a/src/components/color-picker/ColorPicker.tsx
+++ b/src/components/color-picker/ColorPicker.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
 } from "react";
+import "./ColorPicker.css";
 import { getValidSourceColor } from "../../utils/color-utils.ts";
 
 /**

--- a/src/components/footer/Footer.css
+++ b/src/components/footer/Footer.css
@@ -1,0 +1,27 @@
+.footer {
+  height: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-16);
+  flex-wrap: nowrap;
+}
+
+.footer-element {
+  padding: var(--spacing-4);
+  text-decoration: none;
+  color: var(--foreground-secondary);
+
+  &:visited {
+    color: inherit;
+    text-decoration: inherit;
+  }
+}
+
+.footer-divider {
+  display: inline-block;
+  width: 1px;
+  height: var(--spacing-12);
+  background-color: var(--background-quaternary);
+  vertical-align: middle;
+}

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,0 +1,33 @@
+import "./Footer.css";
+
+const Footer: React.FC = () => {
+  return (
+    <div className="footer">
+      <a
+        className="footer-element body-s"
+        href="https://github.com/malliaridis/penpot-plugin-material-theme-builder/blob/main/docs/getting-started.md"
+        target="_blank"
+      >
+        Instructions
+      </a>
+      <div className="footer-divider"></div>
+      <a
+        className="footer-element body-s"
+        href="https://github.com/malliaridis/penpot-plugin-material-theme-builder/"
+        target="_blank"
+      >
+        GitHub
+      </a>
+      <div className="footer-divider"></div>
+      <a
+        className="footer-element body-s"
+        href="https://material.io/"
+        target="_blank"
+      >
+        material.io
+      </a>
+    </div>
+  );
+};
+
+export default Footer;

--- a/src/style.css
+++ b/src/style.css
@@ -10,8 +10,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-
-  padding: 8px 0;
 }
 
 p {
@@ -26,80 +24,7 @@ p {
   width: 100%;
 }
 
-.color-input {
-  padding-block: 0;
-  padding-inline: var(--spacing-8) 0;
-  height: var(--spacing-32);
-  display: flex;
-  gap: 8px;
+.checkbox-container {
   align-items: center;
-  border: 1px transparent solid;
-
-  &:focus-within {
-    background: var(--background-primary);
-    border: 1px var(--accent-primary) solid;
-  }
-
-  &:hover:focus-within {
-    background: var(--background-primary);
-    border: 1px var(--accent-primary) solid;
-  }
-}
-
-.color-input-color {
-  border-radius: var(--spacing-4);
-  width: 14px;
-  height: 14px;
-  background: white;
-  outline: 2px transparent solid;
-}
-
-.color-input-color:hover {
-  outline: 2px var(--accent-primary) solid;
-}
-
-.color-input-text {
-  background-color: transparent !important;
-  border: none;
-  flex: 1;
-  font-family: "worksans", "vazirmatn", sans-serif;
-  font-weight: var(--font-weight-regular);
-  font-size: var(--font-size-m);
-  line-height: var(--font-line-height-l);
-  padding-block: var(--spacing-4);
-
-  :focus {
-    border: 0 transparent solid;
-    outline: 0 transparent solid;
-  }
-}
-
-.color-picker {
-  border: none;
-  width: 14px;
-  height: 14px;
-  cursor: pointer;
-  background: none;
-  padding: 0;
-  padding-block: 0;
-  padding-inline: 0;
-  border-radius: var(--spacing-4);
-}
-
-.color-picker::-webkit-color-swatch-wrapper {
-  width: 14px;
-  height: 14px;
-  padding: 0;
-  padding-block: 0;
-  padding-inline: 0;
-}
-
-.color-picker::-webkit-color-swatch {
-  width: 14px;
-  height: 14px;
-  border: none;
-}
-
-.color-picker:hover {
-  outline: 2px var(--accent-primary) solid;
+  height: var(--spacing-32);
 }


### PR DESCRIPTION
## Description

This PR adds some minor features and cleanups. 

- Add a footer component that is displayed at the bottom of the App component
- Move the ColorPicker CSS to ColorPicker.css to reduce the cluttering in style.css
- Add additional options with a checkbox for allowing user to generate tonal palettes as well

## Checklist

- [x] Code adheres to the project coding style.
- [x] All existing tests pass.
- [ ] New tests have been added for the changes (if applicable).
- [x] Linting checks have passed (`npm run lint`).
- [x] The project builds successfully (`npm run build`).
- [ ] Relevant documentation has been updated (if applicable).

## How Has This Been Tested?

Manually tested at https://design.penpot.app/

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Documentation update (non-code changes, such as markdown files, README
      updates, etc.)
