### PR TITLE
Add progress bar during generation and updating

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -63,3 +63,11 @@
     color: var(--background-quaternary);
   }
 }
+
+.primary {
+  color: var(--foreground-primary);
+}
+
+.secondary {
+  color: var(--foreground-secondary);
+}

--- a/src/components/color-picker/ColorPicker.css
+++ b/src/components/color-picker/ColorPicker.css
@@ -16,6 +16,17 @@
     background: var(--background-primary);
     border: 1px var(--accent-primary) solid;
   }
+
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
+    background-color: var(--background-primary);
+    border-color: var(--background-quaternary);
+
+    &:hover {
+      background-color: var(--background-primary);
+      border-color: var(--background-quaternary);
+    }
+  }
 }
 
 .color-input-color {
@@ -40,9 +51,13 @@
   line-height: var(--font-line-height-l);
   padding-block: var(--spacing-4);
 
-  :focus {
+  &:focus {
     border: 0 transparent solid;
     outline: 0 transparent solid;
+  }
+
+  &:disabled {
+    color: var(--foreground-secondary);
   }
 }
 
@@ -74,4 +89,10 @@
 
 .color-picker:hover {
   outline: 2px var(--accent-primary) solid;
+}
+
+.color-picker:disabled {
+  outline: 2px transparent solid;
+  cursor: not-allowed;
+  opacity: 0.5;
 }

--- a/src/components/color-picker/ColorPicker.tsx
+++ b/src/components/color-picker/ColorPicker.tsx
@@ -16,6 +16,11 @@ interface ColorPickerProps {
    *  The initial color to use.
    */
   color?: string;
+
+  /**
+   * Whether the input field is disabled.
+   */
+  disabled: boolean;
 }
 
 /**
@@ -76,7 +81,11 @@ const ColorPicker = forwardRef<ColorPickerRef, ColorPickerProps>(
         >
           Source Color
         </label>
-        <div id="source-color-input" className="input color-input" tabIndex={3}>
+        <div
+          id="source-color-input"
+          className="input color-input"
+          aria-disabled={props.disabled}
+        >
           <input
             type="color"
             ref={inputRef}
@@ -86,6 +95,7 @@ const ColorPicker = forwardRef<ColorPickerRef, ColorPickerProps>(
             onChange={(e) => {
               updateColor(e.target.value);
             }}
+            disabled={props.disabled}
           />
           <input
             type="text"
@@ -96,6 +106,7 @@ const ColorPicker = forwardRef<ColorPickerRef, ColorPickerProps>(
             onChange={(e) => {
               setInputColor(e.target.value);
             }}
+            disabled={props.disabled}
           />
         </div>
       </div>

--- a/src/components/theme-selector/ThemeSelector.css
+++ b/src/components/theme-selector/ThemeSelector.css
@@ -1,6 +1,17 @@
 .select {
   align-content: center;
   background: none;
+
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
+    background-color: var(--background-primary);
+    border-color: var(--background-quaternary);
+
+    &:hover {
+      background-color: var(--background-primary);
+      border-color: var(--background-quaternary);
+    }
+  }
 }
 
 .select-active {

--- a/src/components/theme-selector/ThemeSelector.tsx
+++ b/src/components/theme-selector/ThemeSelector.tsx
@@ -27,6 +27,11 @@ interface ThemeSelectorProps {
    * a new theme, for example.
    */
   onThemeChanged: (themeName: string | undefined) => void;
+
+  /**
+   * Whether the theme selector should be disabled.
+   */
+  disabled: boolean;
 }
 
 const ThemeSelector: React.FC<ThemeSelectorProps> = ({
@@ -34,6 +39,7 @@ const ThemeSelector: React.FC<ThemeSelectorProps> = ({
   allowNewTheme,
   currentTheme,
   onThemeChanged,
+  disabled,
 }: ThemeSelectorProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -53,10 +59,12 @@ const ThemeSelector: React.FC<ThemeSelectorProps> = ({
     <div className="form-group">
       <span className="input-label body-m">Theme</span>
       <div
+        tabIndex={0}
         className={isOpen ? "select select-active" : "select"}
         onClick={() => {
-          setIsOpen(!isOpen);
+          setIsOpen(!disabled && !isOpen);
         }}
+        aria-disabled={disabled}
       >
         <div className="selected-option">
           {currentTheme ? (

--- a/src/components/toast-loader/ToastLoader.css
+++ b/src/components/toast-loader/ToastLoader.css
@@ -1,0 +1,27 @@
+.toast-loader {
+  position: absolute;
+  bottom: 0;
+  background-color: var(--background-primary);
+  width: 100%;
+  border: 1px var(--background-quaternary) solid;
+  border-radius: var(--spacing-8);
+}
+
+.toast-loader-content {
+  padding: var(--spacing-8);
+  width: 100%;
+  display: flex;
+  gap: var(--spacing-8);
+}
+
+.toast-progress-bar {
+  bottom: 0;
+  width: 100%;
+  height: var(--spacing-4);
+  background-color: var(--background-quaternary);
+}
+
+.toast-progress-bar-indicator {
+  height: var(--spacing-4);
+  background-color: var(--accent-primary);
+}

--- a/src/components/toast-loader/ToastLoader.tsx
+++ b/src/components/toast-loader/ToastLoader.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from "react";
+import "./ToastLoader.css";
+import { X } from "react-feather";
+
+interface ToastLoaderProps {
+  children: ReactNode;
+  progress: number;
+  close: (() => void) | undefined;
+}
+
+const ToastLoader: React.FC<Partial<ToastLoaderProps>> = ({
+  children,
+  progress = 0,
+  close = undefined,
+}: Partial<ToastLoaderProps> = {}) => {
+  return (
+    <div className="toast-loader">
+      <div className="toast-loader-content">
+        {children}
+        {close && <X onClick={close} />}
+      </div>
+      <div className="toast-progress-bar">
+        <div
+          className="toast-progress-bar-indicator"
+          style={{ width: (progress * 100).toString() + "%" }}
+        ></div>
+      </div>
+    </div>
+  );
+};
+
+export { ToastLoader };

--- a/src/style.css
+++ b/src/style.css
@@ -18,14 +18,27 @@ p {
 
 .input {
   width: 100%;
+
+  &:disabled {
+    color: var(--foreground-secondary);
+  }
 }
 
 .checkbox-container {
   align-items: center;
   height: var(--spacing-32);
+
+  &[aria-disabled="true"] {
+    cursor: progress;
+
+    label {
+      cursor: progress;
+    }
+  }
 }
 
 .checkbox-input[type="checkbox"]:checked:disabled {
   background-color: var(--foreground-secondary);
   border: 1px solid var(--foreground-secondary);
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## Description

This PR adds a notifcation / toast loader that displays the current progress when generating or updating a theme.

It also disables any fields during generation to prevent multiple executions.

Closes #13 

## Checklist

<!--
Please ensure the following checks are completed before requesting a review:
-->

- [x] Code adheres to the project coding style.
- [x] All existing tests pass.
- [ ] New tests have been added for the changes (if applicable).
- [x] Linting checks have passed (`npm run lint`).
- [x] The project builds successfully (`npm run build`).
- [ ] Relevant documentation has been updated (if applicable).

## How Has This Been Tested?

Manually tested at https://design.penpot.app/

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Documentation update (non-code changes, such as markdown files, README
      updates, etc.)
