### PR TITLE
Add support for swapping colors from strokes and shadows

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -18,6 +18,7 @@ import {
   LibraryColor,
   Page,
   Shape,
+  Stroke,
 } from "@penpot/plugin-types";
 
 penpot.ui.open("Material Theme Builder", `?theme=${penpot.theme}`);
@@ -282,7 +283,7 @@ function updateShapeColors(shapes: Shape[], mappings: ColorMap, ref: number) {
 
         if (actualColor) {
           updated = true;
-          return actualColor.asStroke();
+          return updateAndGetStroke(stroke, actualColor);
         }
       }
       return stroke;
@@ -308,6 +309,28 @@ function updateShapeColors(shapes: Shape[], mappings: ColorMap, ref: number) {
       ref,
     } as PenpotMappingData,
   });
+}
+
+/**
+ * Generates a new stroke from {@code color} and applies metadata like opacity
+ * and stroke width from existing {@code stroke}.
+ *
+ * This additional mapping is necessary because converting a color to a stroke
+ * would reset existing values.
+ *
+ * @param stroke The existing stroke to update the color / use the metadata from
+ * @param color The color to use for the new stroke
+ * @return a new Stroke
+ */
+function updateAndGetStroke(stroke: Stroke, color: LibraryColor) {
+  const newStroke = color.asStroke(); // covers color values and opacity
+  newStroke.strokeAlignment = stroke.strokeAlignment;
+  newStroke.strokeStyle = stroke.strokeStyle;
+  newStroke.strokeCapStart = stroke.strokeCapStart;
+  newStroke.strokeCapEnd = stroke.strokeCapEnd;
+  newStroke.strokeWidth = stroke.strokeWidth;
+  newStroke.strokeColorGradient = stroke.strokeColorGradient;
+  return newStroke;
 }
 
 /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,6 +17,7 @@ import {
   Library,
   LibraryColor,
   Page,
+  Shadow,
   Shape,
   Stroke,
 } from "@penpot/plugin-types";
@@ -249,6 +250,8 @@ function updateShapeColors(shapes: Shape[], mappings: ColorMap, ref: number) {
   shapes.forEach((shape) => {
     const fills = shape.fills;
     const strokes = shape.strokes;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const shadows: Shadow[] = shape.shadows ?? [];
     let updated = false;
 
     const libraryColors = allLibraries().flatMap((library) => library.colors);
@@ -287,6 +290,24 @@ function updateShapeColors(shapes: Shape[], mappings: ColorMap, ref: number) {
         }
       }
       return stroke;
+    });
+
+    shape.shadows = shadows.map((shadow) => {
+      if (shadow.color?.id) {
+        const mappedColor = mappings[shadow.color.id];
+        if (!mappedColor) return shadow;
+
+        const actualColor = libraryColors.find(
+          (color) => color.id == mappedColor.id,
+        );
+
+        if (actualColor) {
+          updated = true;
+          shadow.color = actualColor;
+          return shadow;
+        }
+      }
+      return shadow;
     });
 
     penpot.ui.sendMessage({


### PR DESCRIPTION
## Description

This PR swaps the colors of strokes and shadows together with the fill colors of shapes, as these may also be library color references. For strokes and shadows a custom additional mapping is necessary to keep the additional attributes unmodified.

Closes #63.

## Checklist

<!--
Please ensure the following checks are completed before requesting a review:
-->

- [x] Code adheres to the project coding style.
- [x] All existing tests pass.
- [ ] New tests have been added for the changes (if applicable).
- [x] Linting checks have passed (`npm run lint`).
- [x] The project builds successfully (`npm run build`).
- [x] Relevant documentation has been updated (if applicable).

## How Has This Been Tested?

Tested manually on https://design.penpot.app/.

Note that first CORS issues occurred that required additional workarounds for testing with localhost. This may cause issues in production as well once new release is published.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Documentation update (non-code changes, such as markdown files, README
      updates, etc.)

## Additional Context

An issue with the shape.shadows being `null` was discovered and reported (see https://github.com/penpot/penpot-plugins/issues/191), which is why an eslint check had to be disabled temporarily.